### PR TITLE
Fixing frequency names

### DIFF
--- a/app/src/main/java/com/example/dpoae/CheckProbeFragment.java
+++ b/app/src/main/java/com/example/dpoae/CheckProbeFragment.java
@@ -46,7 +46,7 @@ public class CheckProbeFragment extends Fragment {
     View view;
     int phaseIndex;
     boolean isDrawing;
-    private RadioButton b2, b3, b4;
+    private RadioButton b1, b2, b3;
     int freqIndex;
     AudioStreamer sp;
     private Listener listener;
@@ -100,9 +100,9 @@ public class CheckProbeFragment extends Fragment {
         final Button buttonDraw = view.findViewById(R.id.buttonDraw);
         this.isRunning=true;
         this.isDrawing=false;
-        b2 = (RadioButton)view.findViewById(R.id.khz2);
-        b3 = (RadioButton)view.findViewById(R.id.khz3);
-        b4 = (RadioButton)view.findViewById(R.id.khz4);
+        b1 = (RadioButton)view.findViewById(R.id.khz3);
+        b2 = (RadioButton)view.findViewById(R.id.khz4);
+        b3 = (RadioButton)view.findViewById(R.id.khz5);
 
         // Find the RadioGroup in the layout. Add a listener to update frequency.
         RadioGroup radioGroup = view.findViewById(R.id.idRadioGroup);
@@ -320,11 +320,11 @@ public class CheckProbeFragment extends Fragment {
     private void UpdateFreqIndex() {
         // get newFeqIndex from radio button
         int newFreqIndex = 0;
-        if (b3.isChecked()) {
+        if (b2.isChecked()) {
             newFreqIndex = 2;
-        } else if (b4.isChecked()) {
+        } else if (b3.isChecked()) {
             newFreqIndex = 3;
-        } else if (b2.isChecked()) {
+        } else if (b1.isChecked()) {
             newFreqIndex = 1;
         } else {
             newFreqIndex = 0;

--- a/app/src/main/res/layout/probe_check.xml
+++ b/app/src/main/res/layout/probe_check.xml
@@ -89,11 +89,6 @@ android:scrollbars="none" >
         app:layout_constraintTop_toTopOf="@+id/buttonDraw"
         tools:ignore="MissingConstraints" >
         <RadioButton
-            android:id="@+id/khz1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="1kHz"/>
-        <RadioButton
             android:id="@+id/khz2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -108,6 +103,11 @@ android:scrollbars="none" >
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="4kHz"/>
+        <RadioButton
+            android:id="@+id/khz5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="5kHz"/>
     </RadioGroup>
 
 </LinearLayout>

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Sep 23 17:34:19 PDT 2024
-sdk.dir=C\:\\Users\\kaya\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Renaming '1kHz' as '2kHz' to be consistent with the rest of the labels. Same for 2, 3 and 4KHz